### PR TITLE
Add actuator and validation support for Kubernetes health checks

### DIFF
--- a/organicoffee-service.yaml
+++ b/organicoffee-service.yaml
@@ -24,11 +24,15 @@ spec:
             - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=75.0"
           readinessProbe:
-            httpGet: { path: /actuator/health, port: 8089 }
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8089
             initialDelaySeconds: 10
             periodSeconds: 10
           livenessProbe:
-            httpGet: { path: /actuator/health, port: 8089 }
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8089
             initialDelaySeconds: 30
             periodSeconds: 20
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,22 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <!-- Bean validation support -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
+
+                <!-- Actuator endpoints for health checks -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                </dependency>
 
     <!-- Driver PostgreSQL -->
     <dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,7 @@ server.port=8089
 # (Opcional) logs de SQL/conn
 # logging.level.org.hibernate.orm.connections.pooling=INFO
 # logging.level.com.zaxxer.hikari=INFO
+
+# Actuator configuration for Kubernetes probes
+management.endpoints.web.exposure.include=health
+management.endpoint.health.probes.enabled=true


### PR DESCRIPTION
## Summary
- include spring-boot-starter-actuator and spring-boot-starter-validation dependencies
- expose health probe endpoints in application properties
- configure Kubernetes probes for readiness and liveness endpoints

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0af08887483248cb45ae6984ff1fa