### PR TITLE
Add Jakarta Bean Validation dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                  <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter-web</artifactId>
+                  </dependency>
+                  <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter-validation</artifactId>
+                  </dependency>
 
-    <!-- Driver PostgreSQL -->
+      <!-- Driver PostgreSQL -->
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>


### PR DESCRIPTION
## Summary
- include Spring Boot's validation starter for Jakarta Bean Validation support

## Testing
- `mvn -q package` *(fails: Non-resolvable parent POM - Could not transfer artifact org.springframework.boot:spring-boot-starter-parent: Network is unreachable)*
- `docker build -t organicoffee-service:latest .` *(fails: command not found: docker)*
- `kubectl apply -f organicoffee-service.yaml` *(fails: command not found: kubectl)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b704e1488324b9e2dc072a3382d5